### PR TITLE
Add minimal Next.js setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.next/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # keycloak-login
+
+This repository now includes a minimal [Next.js](https://nextjs.org/) setup.
+
+## Running locally
+
+After cloning the repository, install dependencies and start the development server:
+
+```bash
+npm install
+npm run dev
+```
+
+Open `http://localhost:3000` in your browser to see the app.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "keycloak-login",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.2.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <h1>Hello, Next.js!</h1>;
+}


### PR DESCRIPTION
## Summary
- initialize package.json and add Next.js dependencies
- add minimal index page and `.gitignore`
- update README with local run instructions

## Testing
- `npm run build` *(fails: next not found)*
- `npm install next react react-dom` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686eb138216c8333b777f818ed1730a1