### PR TITLE
Add Dockerfile for Next.js app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:18-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+RUN npm run build
+
+EXPOSE 3000
+CMD ["npm", "start"]


### PR DESCRIPTION
## Summary
- add a Dockerfile to containerize the Next.js application

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ff9b1ec0083339643224ff9070ecb